### PR TITLE
Switch to 2.0.0 because of breaking change in "Sync" method signature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ It's suggested that all settings are put on [Azure Configure app settings](https
 
 ### Synchronisation
 When everything is set up, you simply make a request on your staging slot: https://your-staging-website/umbraco/wavenet/slotcopy/sync
-and it will return the number of items copied from source to target.  
+and it will show the synchronisation progress.  
 If you run the same on production, it will reject the request with a 404 (check based on `UmbracoSlotCopy::ServerToSync`)
 
 ### Integration / Build Server

--- a/Wavenet.Umbraco7.SlotCopy.csproj
+++ b/Wavenet.Umbraco7.SlotCopy.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://www.wavenet.be/favicon.ico</PackageIconUrl>
     <RepositoryUrl>https://github.com/wavenet-be/Wavenet.Umbraco7.SlotCopy/</RepositoryUrl>
     <PackageTags>Umbraco7 Azure Slot</PackageTags>
-    <Version>1.0.1</Version>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Wavenet.Umbraco7.SlotCopy.xml
+++ b/Wavenet.Umbraco7.SlotCopy.xml
@@ -15,7 +15,9 @@
             <summary>
             Downloads the requested file in the token.
             </summary>
-            <returns>The requested file.</returns>
+            <returns>
+            The requested file.
+            </returns>
         </member>
         <member name="M:Wavenet.Umbraco7.SlotCopy.SlotCopyController.ExecuteAsync(System.Web.Http.Controllers.HttpControllerContext,System.Threading.CancellationToken)">
             <summary>
@@ -37,10 +39,10 @@
         </member>
         <member name="M:Wavenet.Umbraco7.SlotCopy.SlotCopyController.Sync">
             <summary>
-            Synchronizes files from target server.
+            Synchronises files from target server.
             </summary>
             <returns>
-            Number of item.
+            Synchronisation status.
             </returns>
         </member>
         <member name="M:Wavenet.Umbraco7.SlotCopy.SlotCopyController.GetFileList(System.Net.WebClient,System.Uri)">
@@ -52,6 +54,21 @@
             <returns>
             The file list.
             </returns>
+        </member>
+        <member name="M:Wavenet.Umbraco7.SlotCopy.SlotCopyController.WriteLine(System.IO.Stream,System.String)">
+            <summary>
+            Writes the <paramref name="line"/> on the specified <paramref name="stream"/>.
+            </summary>
+            <param name="stream">The stream.</param>
+            <param name="line">The line.</param>
+        </member>
+        <member name="M:Wavenet.Umbraco7.SlotCopy.SlotCopyController.StreamSync(System.IO.Stream,System.Net.Http.HttpContent,System.Net.TransportContext)">
+            <summary>
+            Log synchronisation progress.
+            </summary>
+            <param name="stream">The stream.</param>
+            <param name="content">The content.</param>
+            <param name="transportContext">The transport context.</param>
         </member>
         <member name="T:Wavenet.Umbraco7.SlotCopy.Helpers.Base64UrlEncoder">
             <summary>


### PR DESCRIPTION
Now "sync" sends the progress of synchronisation.
This should avoid the risk of timeout from Azure load balancer.

Fix:
- Ensure TLS 1.2 to avoid error in legacy websites.
- Crash on set "LastWriteTimeUtc", now it is done on the temp file before copy.